### PR TITLE
Change parallel implementation

### DIFF
--- a/R/tune_rknnim.R
+++ b/R/tune_rknnim.R
@@ -82,11 +82,11 @@ inject_na <- function(
 #'
 #' This function tunes the parameters for the [rknnim()]/[knn_imp()] imputation method by injecting missing values
 #' into the dataset multiple times and evaluating the imputation performance for different parameter
-#' combinations. Set \code{n.feat = ncol(obj)} and \code{n.overlap = 0} to tune [knn_imp()]
+#' combinations. Set \code{n_feat = ncol(obj)} and \code{n_overlap = 0} to tune [knn_imp()]
 #'
 #' @inheritParams rknnim
 #' @param parameters A data frame specifying the parameter combinations to tune. Must include columns
-#'   `n.feat`, `k`, `n.overlap` and `method`. Duplicate rows are automatically removed.
+#'   `n_feat`, `k`, `n_overlap` and `method`. Duplicate rows are automatically removed.
 #' @param rep The number of repetitions for injecting missing values and evaluating parameters.
 #'   Default is 1.
 #' @param verbose Print out progress? Default is TRUE.
@@ -97,7 +97,7 @@ inject_na <- function(
 #'   \itemize{
 #'     \item `rep`: The repetition number.
 #'     \item `param_id`: The ID of the parameter combination.
-#'     \item `n.feat`, `k`, `n.overlap`, `method`: The parameter values used.
+#'     \item `n_feat`, `k`, `n_overlap`, `method`: The parameter values used.
 #'     \item `result`: A nested tibble with columns `truth` (original values) and `estimate`
 #'       (imputed values) for the injected NAs.
 #'   }
@@ -107,9 +107,9 @@ inject_na <- function(
 #' data(khanmiss1)
 #'
 #' parameters <- dplyr::tibble(
-#'   n.feat = c(100, 100, 100),
+#'   n_feat = c(100, 100, 100),
 #'   k = c(5, 10, 10),
-#'   n.overlap = c(10, 10, 10),
+#'   n_overlap = c(10, 10, 10),
 #'   method = "euclidean"
 #' )
 #'
@@ -158,9 +158,9 @@ tune_rknnim <- function(
   )
   checkmate::assert_count(rep, positive = TRUE)
   checkmate::assert_logical(verbose, any.missing = FALSE, len = 1)
-  stopifnot(all(c("n.feat", "k", "n.overlap", "method") %in% names(parameters)))
+  stopifnot(all(c("n_feat", "k", "n_overlap", "method") %in% names(parameters)))
   # de-dup the parameter
-  parameters <- unique(subset(parameters, select = c("n.feat", "k", "n.overlap", "method")))
+  parameters <- unique(subset(parameters, select = c("n_feat", "k", "n_overlap", "method")))
   na_loc <- replicate(
     n = rep,
     inject_na(
@@ -196,9 +196,9 @@ tune_rknnim <- function(
       # Imputation
       imputed_vec <- rknnim(
         obj = pre,
-        n.feat = current_params$n.feat,
+        n_feat = current_params$n_feat,
         k = current_params$k,
-        n.overlap = current_params$n.overlap,
+        n_overlap = current_params$n_overlap,
         method = current_params$method,
         rowmax = rowmax,
         colmax = colmax,
@@ -211,9 +211,9 @@ tune_rknnim <- function(
       run_result <- tibble::tibble(
         rep = i,
         param_id = j,
-        n.feat = current_params$n.feat,
+        n_feat = current_params$n_feat,
         k = current_params$k,
-        n.overlap = current_params$n.overlap,
+        n_overlap = current_params$n_overlap,
         result = list(tibble::tibble(truth = truth_vec, estimate = imputed_vec))
       )
       results_list[[z]] <- run_result

--- a/man/inject_na.Rd
+++ b/man/inject_na.Rd
@@ -7,7 +7,7 @@
 inject_na(obj, num_na = 100, rowmax = 0.9, colmax = 0.9, max_iter = 1000)
 }
 \arguments{
-\item{obj}{A numeric matrix with \strong{samples in rows} and \strong{features in columns}.}
+\item{obj}{A numeric matrix with \strong{samples in rows} and \strong{features in columns}. See details.}
 
 \item{num_na}{The number of missing values used to estimate prediction quality. Must be a positive integer.}
 

--- a/man/knn_imp.Rd
+++ b/man/knn_imp.Rd
@@ -10,11 +10,12 @@ knn_imp(
   colmax = 0.9,
   rowmax = 0.9,
   method = c("euclidean", "manhattan", "impute.knn"),
-  cores = 1
+  cores = 1,
+  post_imp = TRUE
 )
 }
 \arguments{
-\item{obj}{A numeric matrix with \strong{samples in rows} and \strong{features in columns}.}
+\item{obj}{A numeric matrix with \strong{samples in rows} and \strong{features in columns}. See details.}
 
 \item{k}{An integer specifying the number of nearest neighbors to use for
 imputation. Must be between 1 and the number of columns.}
@@ -29,28 +30,36 @@ exceeds this threshold, the function will stop with an error.}
 
 \item{method}{A character string specifying the distance metric for k-NN.
 Acceptable values are `"euclidean"`, `"manhattan"`, or `"impute.knn"`.
-Defaults to `"euclidean"`. See [knn_imp()].}
+Defaults to `"euclidean"`. See details.}
 
-\item{cores}{Number of cores to parallelize calculations of distances over. Note: if .parallel is TRUE and cores = n, then each mirai::daemons() process will spawn n cores.}
+\item{cores}{Number of cores to parallelize calculations of distances over. Note: if \code{.parallel} is TRUE and cores = n, then each [mirai::daemons()] process will spawn n cores.}
+
+\item{post_imp}{KNN impute can fail. Retry with mean imputation or not? Default is TRUE.}
 }
 \value{
-A numeric matrix of the same dimensions as `obj` with missing values
-  imputed.
+A numeric matrix of the same dimensions as \code{obj} with missing values imputed.
 }
 \description{
 This function imputes missing values in a numeric matrix using the k-Nearest
 Neighbors algorithm. It follows a two-stage process. First, it imputes
 columns with a proportion of missing values below `colmax` using k-NN.
-Second, any remaining missing values (including those in columns that
-exceeded `colmax`) are imputed using the column mean.
+Second, if requested, any remaining missing values are imputed using the column mean.
 }
 \details{
+This implementation calculates the distances for neighbors column-wise. This is an
+\strong{extremely} important detail. Outside of microarray data, most datasets have
+people in columns and features (e.g., weight, height, etc.) in rows for imputation
+However, in microarray data, genes or CpG sites for the same sample that are
+spatially closer together carry mutual information, so you can place genes in columns
+and samples in rows; the algorithm will then impute values based on nearby genes
+for the same sample.
+
 The distance calculation between columns for identifying nearest neighbors is
 scaled based on the number of non-missing value pairs. Specifically, the
 raw distance is penalized by scaling it up for columns that have fewer
 overlapping observations. This penalizes distances for columns with very few
 shared observations used for distance calculations. The
-`impute.knn` method averages the distances over the number of matching positions,
+\code{impute.knn} method averages the distances over the number of matching positions,
 so a column with only one matching value to calculate distance from might have a lower
 raw distance than a column with many matched values. See also [stats::dist()].
 }

--- a/man/mean_impute_col.Rd
+++ b/man/mean_impute_col.Rd
@@ -7,12 +7,12 @@
 mean_impute_col(obj)
 }
 \arguments{
-\item{obj}{A numeric matrix with \strong{samples in rows} and \strong{features in columns}.}
+\item{obj}{A numeric matrix with \strong{samples in rows} and \strong{features in columns}. See details.}
 }
 \value{
-The matrix with NA values replaced by row means.
+The matrix with NA values replaced by col means.
 }
 \description{
 Imputes missing values (NA) in a matrix by replacing them with the mean of their
-respective col, computed excluding NA values.
+respective cols.
 }

--- a/man/mean_impute_row.Rd
+++ b/man/mean_impute_row.Rd
@@ -7,12 +7,12 @@
 mean_impute_row(obj)
 }
 \arguments{
-\item{obj}{A numeric matrix with \strong{samples in rows} and \strong{features in columns}.}
+\item{obj}{A numeric matrix with \strong{samples in rows} and \strong{features in columns}. See details.}
 }
 \value{
 The matrix with NA values replaced by row means.
 }
 \description{
 Imputes missing values (NA) in a matrix by replacing them with the mean of their
-respective rows, computed excluding NA values.
+respective rows.
 }

--- a/man/rknnim.Rd
+++ b/man/rknnim.Rd
@@ -6,23 +6,24 @@
 \usage{
 rknnim(
   obj,
-  n.feat,
-  n.overlap = 10,
+  n_feat,
+  n_overlap = 10,
   k = 10,
   rowmax = 0.9,
   colmax = 0.9,
   cores = 1,
   method = c("euclidean", "manhattan", "impute.knn"),
+  post_imp = TRUE,
   .progress = FALSE,
   .parallel = FALSE
 )
 }
 \arguments{
-\item{obj}{A numeric matrix with \strong{samples in rows} and \strong{features in columns}.}
+\item{obj}{A numeric matrix with \strong{samples in rows} and \strong{features in columns}. See details.}
 
-\item{n.feat}{Integer specifying the number of features (columns) in each window. Must be between 2 and the number of columns in \code{obj}.}
+\item{n_feat}{Integer specifying the number of features (columns) in each window. Must be between 2 and the number of columns in \code{obj}.}
 
-\item{n.overlap}{Integer specifying the overlap between consecutive windows. Default is 10. Must be between 0 and \code{n.feat - 1}.}
+\item{n_overlap}{Integer specifying the overlap between consecutive windows. Default is 10. Must be between 0 and \code{n_feat - 1}.}
 
 \item{k}{An integer specifying the number of nearest neighbors to use for
 imputation. Must be between 1 and the number of columns.}
@@ -35,11 +36,13 @@ exceeds this threshold, the function will stop with an error.}
 proportion of missing values in a column. Columns exceeding this
 threshold will be imputed using the column mean instead of k-NN.}
 
-\item{cores}{Number of cores to parallelize calculations of distances over. Note: if .parallel is TRUE and cores = n, then each mirai::daemons() process will spawn n cores.}
+\item{cores}{Number of cores to parallelize calculations of distances over. Note: if \code{.parallel} is TRUE and cores = n, then each [mirai::daemons()] process will spawn n cores.}
 
 \item{method}{A character string specifying the distance metric for k-NN.
 Acceptable values are `"euclidean"`, `"manhattan"`, or `"impute.knn"`.
-Defaults to `"euclidean"`. See [knn_imp()].}
+Defaults to `"euclidean"`. See details.}
+
+\item{post_imp}{KNN impute can fail. Retry with mean imputation or not? Default is TRUE.}
 
 \item{.progress}{Logical indicating whether to show a progress bar. Default is FALSE.}
 
@@ -53,10 +56,13 @@ Performs rolling window KNN imputation on a numeric matrix to handle missing val
 The matrix is divided into overlapping windows, and imputation is applied to each window.
 Overlapping regions are averaged to produce the final imputed matrix.
 }
+\details{
+See [knn_imp()] for details about the implementation.
+}
 \examples{
 \dontrun{
 data(khanmiss1)
-imputed <- rknnim(t(khanmiss1), k = 10, n.feat = 100, n.overlap = 10)
+imputed <- rknnim(t(khanmiss1), k = 10, n_feat = 100, n_overlap = 10)
 }
 
 }

--- a/man/tune_rknnim.Rd
+++ b/man/tune_rknnim.Rd
@@ -18,10 +18,10 @@ tune_rknnim(
 )
 }
 \arguments{
-\item{obj}{A numeric matrix with \strong{samples in rows} and \strong{features in columns}.}
+\item{obj}{A numeric matrix with \strong{samples in rows} and \strong{features in columns}. See details.}
 
 \item{parameters}{A data frame specifying the parameter combinations to tune. Must include columns
-`n.feat`, `k`, `n.overlap` and `method`. Duplicate rows are automatically removed.}
+`n_feat`, `k`, `n_overlap` and `method`. Duplicate rows are automatically removed.}
 
 \item{rep}{The number of repetitions for injecting missing values and evaluating parameters.
 Default is 1.}
@@ -40,7 +40,7 @@ threshold will be imputed using the column mean instead of k-NN.}
 
 \item{verbose}{Print out progress? Default is TRUE.}
 
-\item{cores}{Number of cores to parallelize calculations of distances over. Note: if .parallel is TRUE and cores = n, then each mirai::daemons() process will spawn n cores.}
+\item{cores}{Number of cores to parallelize calculations of distances over. Note: if \code{.parallel} is TRUE and cores = n, then each [mirai::daemons()] process will spawn n cores.}
 
 \item{.parallel}{Logical indicating whether to use parallel processing for multiple windows. Default is FALSE.}
 }
@@ -50,7 +50,7 @@ A tibble containing the tuning results. Each row corresponds to a specific repet
   \itemize{
     \item `rep`: The repetition number.
     \item `param_id`: The ID of the parameter combination.
-    \item `n.feat`, `k`, `n.overlap`, `method`: The parameter values used.
+    \item `n_feat`, `k`, `n_overlap`, `method`: The parameter values used.
     \item `result`: A nested tibble with columns `truth` (original values) and `estimate`
       (imputed values) for the injected NAs.
   }
@@ -58,16 +58,16 @@ A tibble containing the tuning results. Each row corresponds to a specific repet
 \description{
 This function tunes the parameters for the [rknnim()]/[knn_imp()] imputation method by injecting missing values
 into the dataset multiple times and evaluating the imputation performance for different parameter
-combinations. Set \code{n.feat = ncol(obj)} and \code{n.overlap = 0} to tune [knn_imp()]
+combinations. Set \code{n_feat = ncol(obj)} and \code{n_overlap = 0} to tune [knn_imp()]
 }
 \examples{
 \dontrun{
 data(khanmiss1)
 
 parameters <- dplyr::tibble(
-  n.feat = c(100, 100, 100),
+  n_feat = c(100, 100, 100),
   k = c(5, 10, 10),
-  n.overlap = c(10, 10, 10),
+  n_overlap = c(10, 10, 10),
   method = "euclidean"
 )
 

--- a/src/r_impute_cpp_arma.cpp
+++ b/src/r_impute_cpp_arma.cpp
@@ -218,7 +218,7 @@ arma::vec distance_vector(
   // First iterate through all the missing column. Missing columns has 3 parts: 1) i < index
   // if the current column is < index, then the value has already been calculated, fetch from cache.
   // This will run from 0 to right before index
-  for (arma::uword i = 0; i < index; i++)
+  for (arma::uword i = 0; i < index; ++i)
   {
     dist_vec(i) = cache(index, i);
   }
@@ -227,14 +227,14 @@ arma::vec distance_vector(
   dist_vec(index) = arma::datum::inf;
   // 3) then from index to index_miss.n_elem, we calculate and cache the values. Automatically
   // skiped for last missing column where all values are fetched from cache
-  for (arma::uword i = index + 1; i < index_miss.n_elem; i++)
+  for (arma::uword i = index + 1; i < index_miss.n_elem; ++i)
   {
     dist_vec(i) = cache(i, index);
   }
   // Compute the remaining part of the vector (distance from missing to non missing columns).
   // If all columns have missing values (i.e., the matrix is square with
   // obj.n_cols == index_miss.n_elem), this loop is automatically skipped.
-  for (arma::uword i = index_miss.n_elem; i < obj.n_cols; i++)
+  for (arma::uword i = index_miss.n_elem; i < obj.n_cols; ++i)
   {
     // Offset i to index into index_not_miss from 0
     dist_vec(i) = calc_dist(obj, miss, index_miss(index), index_not_miss(i - index_miss.n_elem), total_rows);
@@ -329,9 +329,9 @@ arma::mat impute_knn_naive(
 #if defined(_OPENMP)
 #pragma omp parallel for
 #endif
-  for (arma::uword row = 1; row < col_index_miss.n_elem; row++)
+  for (arma::uword row = 1; row < col_index_miss.n_elem; ++row)
   {
-    for (arma::uword col = 0; col < row; col++)
+    for (arma::uword col = 0; col < row; ++col)
     {
       double dist = calc_dist(obj, miss, col_index_miss(row), col_index_miss(col), total_rows);
       cache(row, col) = dist;
@@ -341,7 +341,7 @@ arma::mat impute_knn_naive(
 #if defined(_OPENMP)
 #pragma omp parallel for
 #endif
-  for (arma::uword i = 0; i < col_index_miss.n_elem; i++)
+  for (arma::uword i = 0; i < col_index_miss.n_elem; ++i)
   {
     arma::vec dist_vec = distance_vector(
         obj, miss, i, col_index_miss, col_index_non_miss, cache, calc_dist);
@@ -368,7 +368,7 @@ arma::mat impute_knn_naive(
       arma::uword count = 0;
 
 #if defined(_OPENMP)
-#pragma omp simd reduction(+ : sum) reduction(+ : count)
+#pragma omp simd reduction(+:sum) reduction(+:count)
 #endif
       for (arma::uword neighbor_col_idx : nn_columns)
       {


### PR DESCRIPTION
Now fill in cache first, which then makes parallelization over columns embarrassingly parallel, which then makes scaling with more scores much more linear